### PR TITLE
rg_tool.py: use python3

### DIFF
--- a/rg_tool.py
+++ b/rg_tool.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import argparse
 import hashlib
 import subprocess


### PR DESCRIPTION
This PR modifies the `rg_tool.py` to use `python3` by default. 

Discussed in: https://github.com/ducalex/retro-go/issues/25#issuecomment-1229557176