### PR TITLE
gnuboy: fix missing lib include

### DIFF
--- a/components/gnuboy/hw.c
+++ b/components/gnuboy/hw.c
@@ -1,4 +1,5 @@
 #include <string.h>
+#include <stdlib.h>
 #include "gnuboy.h"
 #include "sound.h"
 #include "cpu.h"


### PR DESCRIPTION
Due to conflicts so I closed the previos PR and create a new PR here.