### PR TITLE
Upgrade GitHub actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v1
+      uses: docker/setup-buildx-action@v2
 
     - name: Build
       uses: docker/build-push-action@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
         docker run --rm -v $(pwd)/build:/build retro-go:latest sh -c "cp /app/*.fw /build"
 
     - name: Upload artifacts
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: binaries
         path: build/*.fw

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
       uses: docker/setup-buildx-action@v1
 
     - name: Build
-      uses: docker/build-push-action@v2
+      uses: docker/build-push-action@v3
       with:
         context: .
         tags: retro-go:latest


### PR DESCRIPTION
# Description
Upgrade the following GitHub actions in order to remove warnings in the logs.

* actions/checkout@v3
* docker/setup-buildx-action@v2
* docker/build-push-action@v3
* actions/upload-artifact@v3

# Why
Both docker/setup-buildx-action@v1 and docker/build-push-action@v2 are showing the following warning.
```
Warning: The `save-state` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
```
I took the liberty of upgrading the other two github actions since they have newer major versions.