### PR TITLE
Improvements for Retro ESP32 build

### DIFF
--- a/components/retro-go/rg_input.c
+++ b/components/retro-go/rg_input.c
@@ -34,17 +34,32 @@ static inline uint32_t gamepad_read(void)
     int joyX = adc1_get_raw(RG_GPIO_GAMEPAD_X);
     int joyY = adc1_get_raw(RG_GPIO_GAMEPAD_Y);
 
-    if (joyY > 2048 + 1024) state |= RG_KEY_UP;
-    else if (joyY > 1024)   state |= RG_KEY_DOWN;
-    if (joyX > 2048 + 1024) state |= RG_KEY_LEFT;
-    else if (joyX > 1024)   state |= RG_KEY_RIGHT;
-
     if (!gpio_get_level(RG_GPIO_GAMEPAD_MENU))   state |= RG_KEY_MENU;
     if (!gpio_get_level(RG_GPIO_GAMEPAD_OPTION)) state |= RG_KEY_OPTION;
     if (!gpio_get_level(RG_GPIO_GAMEPAD_SELECT)) state |= RG_KEY_SELECT;
     if (!gpio_get_level(RG_GPIO_GAMEPAD_START))  state |= RG_KEY_START;
     if (!gpio_get_level(RG_GPIO_GAMEPAD_A))      state |= RG_KEY_A;
     if (!gpio_get_level(RG_GPIO_GAMEPAD_B))      state |= RG_KEY_B;
+
+    #if RG_SCREEN_TYPE == 32
+        if(joyY > 2048) state |= RG_KEY_UP;
+        if(joyY > 1024 && joyY < 2048) state |= RG_KEY_DOWN;
+        if(joyX > 2048) state |= RG_KEY_LEFT;
+        if(joyX > 1024 && joyX < 2048) state |= RG_KEY_RIGHT;
+
+        if (state == (RG_KEY_SELECT|RG_KEY_A))
+            state = RG_KEY_OPTION;
+
+        if (state == (RG_KEY_START|RG_KEY_SELECT))
+            state = RG_KEY_MENU;
+    #else
+        if (joyY > 2048 + 1024) state |= RG_KEY_UP;
+        else if (joyY > 1024)   state |= RG_KEY_DOWN;
+        if (joyX > 2048 + 1024) state |= RG_KEY_LEFT;
+        else if (joyX > 1024)   state |= RG_KEY_RIGHT;
+
+
+    #endif
 
 #elif RG_GAMEPAD_DRIVER == 2  // Serial
     gpio_set_level(RG_GPIO_GAMEPAD_LATCH, 0);

--- a/components/retro-go/targets/retro-esp32.h
+++ b/components/retro-go/targets/retro-esp32.h
@@ -23,7 +23,7 @@
 #define RG_SCREEN_ROTATE            0
 #define RG_SCREEN_MARGIN_TOP        0
 #define RG_SCREEN_MARGIN_BOTTOM     0
-#define RG_SCREEN_MARGIN_LEFT       0
+#define RG_SCREEN_MARGIN_LEFT       15
 #define RG_SCREEN_MARGIN_RIGHT      20
 
 // Input


### PR DESCRIPTION
> Screen Adjustments

* Once the glass / plastic screen protector is on the case, the screen bleeds behind the lens. Added `RG_SCREEN_MARGIN_LEFT`

> ADC Sampling

* Adjusted ADC level for Retro ESP32 due to resistors slightly different tolerance
* Consists of 2 `if` statements rather than `if..else if`