### PR TITLE
launcher/rg_network: Adding pre-configured Wifi Select option

### DIFF
--- a/components/retro-go/rg_network.h
+++ b/components/retro-go/rg_network.h
@@ -29,4 +29,7 @@ bool rg_network_wifi_start_ap(const char *ssid, const char *password, int channe
 bool rg_network_wifi_start(const char *ssid, const char *password, int channel);
 void rg_network_wifi_stop(void);
 bool rg_network_sync_time(const char *host, int *out_delta);
+void rg_network_set_wifi_slot(int slot);
+int rg_network_get_wifi_slot(void);
+void rg_network_get_ap_list(void);
 rg_network_t rg_network_get_info(void);

--- a/components/retro-go/rg_network_wifi.h
+++ b/components/retro-go/rg_network_wifi.h
@@ -1,0 +1,8 @@
+#pragma once
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#define MAX_AP_LIST 5
+
+char *ap_list[MAX_AP_LIST];

--- a/launcher/main/main.c
+++ b/launcher/main/main.c
@@ -1,4 +1,5 @@
 #include <rg_system.h>
+#include <rg_network_wifi.h>
 #include <sys/time.h>
 #include <stdarg.h>
 #include <stdio.h>
@@ -109,6 +110,23 @@ static rg_gui_event_t wifi_switch_cb(rg_gui_option_t *option, rg_gui_event_t eve
     return RG_DIALOG_VOID;
 }
 
+static rg_gui_event_t wifi_select_cb(rg_gui_option_t *option, rg_gui_event_t event)
+{
+    rg_gui_option_t options[MAX_AP_LIST + 1];
+    rg_network_get_ap_list();
+    rg_network_set_wifi_slot(rg_network_get_wifi_slot());
+    if (event == RG_DIALOG_ENTER) {
+        for (size_t i = 0; i < MAX_AP_LIST; i++)
+            options[i] = (rg_gui_option_t){i, ap_list[i], NULL, 1, NULL};
+        options[MAX_AP_LIST] = (rg_gui_option_t)RG_DIALOG_CHOICE_LAST;
+        int sel = rg_gui_dialog("Select saved AP", options, 0);
+        if (sel >= 0 && sel < MAX_AP_LIST)
+            rg_network_set_wifi_slot(sel);
+        gui_redraw();
+    }
+    return RG_DIALOG_VOID;
+ }
+
 static rg_gui_event_t webui_switch_cb(rg_gui_option_t *option, rg_gui_event_t event)
 {
     if (event == RG_DIALOG_PREV || event == RG_DIALOG_NEXT) {
@@ -124,6 +142,7 @@ static rg_gui_event_t wifi_options_cb(rg_gui_option_t *option, rg_gui_event_t ev
     {
         const rg_gui_option_t options[] = {
             {0, "Wi-Fi"       , "...", 1, &wifi_switch_cb},
+            {0, "Wi-Fi select", "...", 1, &wifi_select_cb},
             {0, "File server" , "...", 1, &webui_switch_cb},
             {0, "Time sync" , "On", 0, NULL},
             RG_DIALOG_CHOICE_LAST,
@@ -186,6 +205,7 @@ static void retro_loop(void)
     music_init();
 
 #ifdef RG_ENABLE_NETWORKING
+    rg_network_set_wifi_slot(rg_network_get_wifi_slot());
     rg_network_init();
     wifi_set_switch(wifi_get_switch());
     webui_set_switch(webui_get_switch());


### PR DESCRIPTION
I giveup the AP scan because I have no idea about making 'something' to input the password. So I read on ODROID GO forum and get the idea that we will save the APs to config file and select, then load them.

This option(under `Wi-Fi options`) let us select the saved SSIDs from `wifi.json`. Present support saving up to **5 APs**(this can be change by changing the `MAX_AP_LIST`). The `wifi.json` will look like this:
```
{
	"WiFi":	1,
	"HTTPFileServer":	1,
	"slot":	0,

	"ssid0":	"ssid-1",
	"password0":	"password-1",

	"ssid1":	"ssid-2",
	"password1":	"password-2,

	"ssid2":	"ssid-3",
	"password2":	"password-3",

	"ssid3":	"ssid-4",
	"password3":	"password-4",

	"ssid4":	"ssid-5",
	"password4":	"password-5"
}
```

I define the variable to a different header file to get rid of `defined but not used` warning when include them inside `rg_network.h`(building the emulators make the warning)
After select the AP, need to reboot to apply new AP config. Now I'm looking for a way to restart the wifi after the AP is set without rebooting the OGO.
