### PR TITLE
Define Gamepad L and R (0) to fix build

### DIFF
--- a/components/retro-go/targets/mrgc-gbm/config.h
+++ b/components/retro-go/targets/mrgc-gbm/config.h
@@ -64,6 +64,8 @@
 #define RG_GAMEPAD_MAP_B            (1<<7)
 #define RG_GAMEPAD_MAP_X            (0)
 #define RG_GAMEPAD_MAP_Y            (0)
+#define RG_GAMEPAD_MAP_L            (0)
+#define RG_GAMEPAD_MAP_R            (0)
 
 // Battery
 // #define RG_BATTERY_ADC_CHANNEL      ADC1_CHANNEL_0 // Default 0, commented out.


### PR DESCRIPTION
Failed to build without these defined.