### PR TITLE
Fix margins for GameBox Mini

### DIFF
--- a/components/retro-go/targets/mrgc-gbm/config.h
+++ b/components/retro-go/targets/mrgc-gbm/config.h
@@ -16,10 +16,9 @@
 #define RG_SCREEN_HOST              SPI2_HOST
 #define RG_SCREEN_SPEED             SPI_MASTER_FREQ_40M
 #define RG_SCREEN_WIDTH             240
-#define RG_SCREEN_HEIGHT            230 // Value for plastic case. Black bar on bottom for metal case.
+#define RG_SCREEN_HEIGHT            240
 #define RG_SCREEN_ROTATE            0
 #define RG_SCREEN_MARGIN_TOP        38
-#define RG_SCREEN_MARGIN_BOTTOM     10  // Value for plastic case. Black bar on bottom for metal case.
 #define RG_SCREEN_MARGIN_LEFT       0
 #define RG_SCREEN_MARGIN_RIGHT      0
 #define RG_SCREEN_INIT()                                                                                   \
@@ -34,6 +33,13 @@
     ILI9341_CMD(0xE0, 0xD0, 0x00, 0x05, 0x0E, 0x15, 0x0D, 0x37, 0x43, 0x47, 0x09, 0x15, 0x12, 0x16, 0x19); \
     ILI9341_CMD(0xE1, 0xD0, 0x00, 0x05, 0x0D, 0x0C, 0x06, 0x2D, 0x44, 0x40, 0x0E, 0x1C, 0x18, 0x16, 0x19); \
     ILI9341_CMD(0x21);
+
+// Screen margin
+// Uncomment the following line if using a plastic case
+#define RG_SCREEN_MARGIN_BOTTOM     10  // Fullscreen for plastic case. Black bar on bottom for metal case.
+
+// Uncomment the following line if using a metal case
+// #define RG_SCREEN_MARGIN_BOTTOM     0  // Fullscreen for metal case. Cropped on bottom for plastic case.
 
 // Input
 #define RG_GAMEPAD_DRIVER           3   // 1 = ODROID-GO, 2 = Serial, 3 = I2C, 4 = AW9523, 5 = ESPLAY-S3, 6 = SDL2
@@ -63,7 +69,7 @@
 #define RG_BATTERY_CALC_PERCENT(raw) (((raw) - 170) / 30.f * 100.f)
 #define RG_BATTERY_CALC_VOLTAGE(raw) (0)
 
-// Status LED
+// Status LED (Does not seem to be mappable)
 // #define RG_GPIO_LED                 GPIO_NUM_NC
 // #define RG_GPIO_LED                 GPIO_NUM_13 // From OG Firmware
 

--- a/components/retro-go/targets/mrgc-gbm/config.h
+++ b/components/retro-go/targets/mrgc-gbm/config.h
@@ -16,10 +16,10 @@
 #define RG_SCREEN_HOST              SPI2_HOST
 #define RG_SCREEN_SPEED             SPI_MASTER_FREQ_40M
 #define RG_SCREEN_WIDTH             240
-#define RG_SCREEN_HEIGHT            230 // Display height 192 plus margin? Was 232
+#define RG_SCREEN_HEIGHT            230 // Value for plastic case. Black bar on bottom for metal case.
 #define RG_SCREEN_ROTATE            0
 #define RG_SCREEN_MARGIN_TOP        38
-#define RG_SCREEN_MARGIN_BOTTOM     2  // Too little gives you garbage under the bottom bezel.
+#define RG_SCREEN_MARGIN_BOTTOM     10  // Value for plastic case. Black bar on bottom for metal case.
 #define RG_SCREEN_MARGIN_LEFT       0
 #define RG_SCREEN_MARGIN_RIGHT      0
 #define RG_SCREEN_INIT()                                                                                   \


### PR DESCRIPTION
For units with plastic cases, fix bottom margin to have a black bar on the bottom instead of garbage underneath the bezel. For units with metal cases, add the option to use the entire viewable screen.