### PR TITLE
Fix build error if RG_STORAGE_DRIVER == 4 // SPI Flash

### DIFF
--- a/components/retro-go/rg_storage.c
+++ b/components/retro-go/rg_storage.c
@@ -15,6 +15,8 @@
 #include <driver/sdmmc_host.h>
 #include <esp_vfs_fat.h>
 #define SDCARD_DO_TRANSACTION sdmmc_host_do_transaction
+#elif RG_STORAGE_DRIVER == 4
+#include <esp_vfs_fat.h>
 #endif
 
 #if defined(_WIN32) || defined(_WIN64)
@@ -152,8 +154,12 @@ void rg_storage_init(void)
 
 #elif RG_STORAGE_DRIVER == 4 // SPI Flash
 
+    esp_vfs_fat_mount_config_t mount_config = {
+        .format_if_mount_failed = true, // if mount failed, it's probably because it's a clean install so the partition hasn't been formatted yet
+    };
+
     wl_handle_t s_wl_handle = WL_INVALID_HANDLE;
-    esp_err_t err = esp_vfs_fat_spiflash_mount(RG_STORAGE_ROOT, "storage", &s_wl_handle);
+    esp_err_t err = esp_vfs_fat_spiflash_mount(RG_STORAGE_ROOT, "storage", &mount_config, &s_wl_handle);
     error_code = (int)err;
 
 #else // Host (stdlib)


### PR DESCRIPTION
Add missing include for wl_handle_t and pass
esp_vfs_fat_mount_config_t to esp_vfs_fat_spiflash_mount.