### PR TITLE
Initialize all fields of esp_vfs_fat_mount_config_t

### DIFF
--- a/components/retro-go/rg_storage.c
+++ b/components/retro-go/rg_storage.c
@@ -156,6 +156,8 @@ void rg_storage_init(void)
 
     esp_vfs_fat_mount_config_t mount_config = {
         .format_if_mount_failed = true, // if mount failed, it's probably because it's a clean install so the partition hasn't been formatted yet
+        .max_files = 16, // must be initialized, otherwise it will use an uninitialized ("random") value, which can trigger ESP_ERR_NO_MEM if it's a big one
+        .allocation_unit_size = 0 // "Setting this field to 0 will result in allocation unit set to the sector size." - in other words: the default value, which is fine
     };
 
     wl_handle_t s_wl_handle = WL_INVALID_HANDLE;


### PR DESCRIPTION
Leaving max_files uninitialized triggers ESP_ERR_NO_MEM at runtime because it's trying to allocate memory for an unspecified (but large) number of files.

In esp-idf_v4.3/components/fatfs/vfs/vfs_fat.c around line 160:
```
size_t ctx_size = sizeof(vfs_fat_ctx_t) + max_files * sizeof(FIL);
vfs_fat_ctx_t* fat_ctx = (vfs_fat_ctx_t*) ff_memalloc(ctx_size);
if (fat_ctx == NULL) {
    return ESP_ERR_NO_MEM;
}
```
So this needs to be initialized properly.