### PR TITLE
Add RG_STORAGE_FALLBACK_FLASH mechanism

### DIFF
--- a/components/retro-go/rg_storage.c
+++ b/components/retro-go/rg_storage.c
@@ -168,7 +168,7 @@ void rg_storage_init(void)
 
 #endif
 
-#if ( RG_STORAGE_DRIVER == 4 || defined(RG_STORAGE_INTERNAL_FLASH_FALLBACK) ) && ESP_PLATFORM // SPI Flash
+#if ( RG_STORAGE_DRIVER == 4 || defined(RG_STORAGE_INTERNAL_FLASH_FALLBACK) ) && ESP_PLATFORM // SPI Internal Flash
 
     if (error_code) // only if no previous storage was successfully mounted already
     {

--- a/components/retro-go/rg_storage.c
+++ b/components/retro-go/rg_storage.c
@@ -168,7 +168,7 @@ void rg_storage_init(void)
 
 #endif
 
-#if ( RG_STORAGE_DRIVER == 4 || defined(RG_STORAGE_FALLBACK_FLASH) ) && ESP_PLATFORM // SPI Flash
+#if ( RG_STORAGE_DRIVER == 4 || defined(RG_STORAGE_INTERNAL_FLASH_FALLBACK) ) && ESP_PLATFORM // SPI Flash
 
     if (error_code) // only if no previous storage was successfully mounted already
     {


### PR DESCRIPTION
If RG_STORAGE_FALLBACK_FLASH is defined, and retro-go hasn't mounted any other storage, it will fallback to trying to find an internal flash partion labelled 'vfs' and mount it. It will also format it if unformatted.

As this code is only compiled in if RG_STORAGE_FALLBACK_FLASH is defined or RG_STORAGE_DRIVER == 4, it won't increase the filesize unnecessarily.