### PR TITLE
Add support for battery on ADC2

### DIFF
--- a/components/retro-go/rg_input.c
+++ b/components/retro-go/rg_input.c
@@ -304,8 +304,18 @@ void rg_input_init(void)
 #if RG_BATTERY_DRIVER == 1 /* ADC */
     RG_LOGI("Initializing ADC battery driver...");
     if (RG_BATTERY_ADC_UNIT == ADC_UNIT_1)
+    {
         adc1_config_width(ADC_WIDTH_MAX - 1); // there is no adc2_config_width
-    adc1_config_channel_atten(RG_BATTERY_ADC_CHANNEL, ADC_ATTEN_DB_11);
+        adc1_config_channel_atten(RG_BATTERY_ADC_CHANNEL, ADC_ATTEN_DB_11);
+    }
+    else if (RG_BATTERY_ADC_UNIT == ADC_UNIT_2)
+    {
+        adc2_config_channel_atten(RG_BATTERY_ADC_CHANNEL, ADC_ATTEN_DB_11);
+    }
+    else
+    {
+        RG_LOGW("Only ADC1 and ADC2 are supported for ADC battery driver!");
+    }
     esp_adc_cal_characterize(RG_BATTERY_ADC_UNIT, ADC_ATTEN_DB_11, ADC_WIDTH_MAX - 1, 1100, &adc_chars);
 #endif
 

--- a/components/retro-go/rg_input.c
+++ b/components/retro-go/rg_input.c
@@ -301,11 +301,12 @@ void rg_input_init(void)
 #endif
 
 
-#if RG_BATTERY_DRIVER == 1 /* ADC1 */
-    RG_LOGI("Initializing ADC1 battery driver...");
-    adc1_config_width(ADC_WIDTH_MAX - 1);
+#if RG_BATTERY_DRIVER == 1 /* ADC */
+    RG_LOGI("Initializing ADC battery driver...");
+    if (RG_BATTERY_ADC_UNIT == ADC_UNIT_1)
+        adc1_config_width(ADC_WIDTH_MAX - 1); // there is no adc2_config_width
     adc1_config_channel_atten(RG_BATTERY_ADC_CHANNEL, ADC_ATTEN_DB_11);
-    esp_adc_cal_characterize(ADC_UNIT_1, ADC_ATTEN_DB_11, ADC_WIDTH_MAX - 1, 1100, &adc_chars);
+    esp_adc_cal_characterize(RG_BATTERY_ADC_UNIT, ADC_ATTEN_DB_11, ADC_WIDTH_MAX - 1, 1100, &adc_chars);
 #endif
 
     // The first read returns bogus data in some drivers, waste it.

--- a/components/retro-go/rg_system.c
+++ b/components/retro-go/rg_system.c
@@ -186,7 +186,7 @@ static void system_monitor_task(void *arg)
         rg_battery_t battery = rg_input_read_battery();
         if (battery.present)
         {
-            if (battery.level < 2)
+            if (battery.level <= 2)
                 rg_system_set_led((batteryLedState ^= 1));
             else if (batteryLedState)
                 rg_system_set_led((batteryLedState = 0));

--- a/components/retro-go/targets/esp32s3-devkit-c/config.h
+++ b/components/retro-go/targets/esp32s3-devkit-c/config.h
@@ -65,7 +65,8 @@
 
 // Battery
 #define RG_BATTERY_DRIVER           1
-#define RG_BATTERY_ADC_CHANNEL      ADC1_CHANNEL_3
+#define RG_BATTERY_ADC_UNIT         ADC_UNIT_1
+#define RG_BATTERY_ADC_CHANNEL      ADC_CHANNEL_3
 #define RG_BATTERY_CALC_PERCENT(raw) (((raw) * 2.f - 3500.f) / (4200.f - 3500.f) * 100.f)
 #define RG_BATTERY_CALC_VOLTAGE(raw) ((raw) * 2.f * 0.001f)
 

--- a/components/retro-go/targets/esplay-s3/config.h
+++ b/components/retro-go/targets/esplay-s3/config.h
@@ -61,7 +61,8 @@
 
 // Battery
 #define RG_BATTERY_DRIVER           1
-#define RG_BATTERY_ADC_CHANNEL      ADC1_CHANNEL_3
+#define RG_BATTERY_ADC_UNIT         ADC_UNIT_1
+#define RG_BATTERY_ADC_CHANNEL      ADC_CHANNEL_3
 #define RG_BATTERY_CALC_PERCENT(raw) (((raw) * 2.f - 3500.f) / (4200.f - 3500.f) * 100.f)
 #define RG_BATTERY_CALC_VOLTAGE(raw) ((raw) * 2.f * 0.001f)
 

--- a/components/retro-go/targets/odroid-go/config.h
+++ b/components/retro-go/targets/odroid-go/config.h
@@ -62,7 +62,8 @@
 
 // Battery
 #define RG_BATTERY_DRIVER           1
-#define RG_BATTERY_ADC_CHANNEL      ADC1_CHANNEL_0
+#define RG_BATTERY_ADC_UNIT         ADC_UNIT_1
+#define RG_BATTERY_ADC_CHANNEL      ADC_CHANNEL_0
 #define RG_BATTERY_CALC_PERCENT(raw) (((raw) * 2.f - 3500.f) / (4200.f - 3500.f) * 100.f)
 #define RG_BATTERY_CALC_VOLTAGE(raw) ((raw) * 2.f * 0.001f)
 

--- a/components/retro-go/targets/retro-esp32/config.h
+++ b/components/retro-go/targets/retro-esp32/config.h
@@ -64,7 +64,8 @@
 
 // Battery
 #define RG_BATTERY_DRIVER           1
-#define RG_BATTERY_ADC_CHANNEL      ADC1_CHANNEL_0
+#define RG_BATTERY_ADC_UNIT         ADC_UNIT_1
+#define RG_BATTERY_ADC_CHANNEL      ADC_CHANNEL_0
 #define RG_BATTERY_CALC_PERCENT(raw) (((raw) * 2.f - 3500.f) / (4200.f - 3500.f) * 100.f)
 #define RG_BATTERY_CALC_VOLTAGE(raw) ((raw) * 2.f * 0.001f)
 


### PR DESCRIPTION
The Fri3D Camp 2024 badge has the battery on ADC2.

Similarly to the joystick support for ADC2, this change too adds a new configuration setting, RG_BATTERY_ADC_UNIT, which allows for specifying which ADC to use for the battery ADC.