### PR TITLE
buzzer: use LEDC_LOW_SPEED_MODE

### DIFF
--- a/components/retro-go/drivers/buzzer.c
+++ b/components/retro-go/drivers/buzzer.c
@@ -48,7 +48,7 @@ Note that there are some restrictions on how high the PWM frequency can be, and 
 #define SOURCE_CLOCK_MIN_DIVIDER	  2 // divider must be [2-65536], according to the docs
 #define SOURCE_CLOCK_FREQUENCY        80000000
 #define SOURCE_CLOCK_MAX_FREQUENCY    SOURCE_CLOCK_FREQUENCY/SOURCE_CLOCK_MIN_DIVIDER
-#define LEDC_PWM_SPEED_MODE           LEDC_HIGH_SPEED_MODE
+#define LEDC_PWM_SPEED_MODE           LEDC_LOW_SPEED_MODE
 #define LEDC_PWM_CHANNEL              LEDC_CHANNEL_0
 #define LEDC_PWM_TIMER                LEDC_TIMER_0
 #define GENERAL_PURPOSE_TIMER_GROUP   TIMER_GROUP_0


### PR DESCRIPTION
The audio driver seems to work just as well with LEDC_LOW_SPEED_MODE as with LEDC_HIGH_SPEED_MODE,
and LEDC_HIGH_SPEED_MODE isn't defined on esp-idf 5.x, so which to LEDC_LOW_SPEED_MODE to fix compilation.