### PR TITLE
Updater: allow longer update names to be shown

### DIFF
--- a/launcher/main/updater.c
+++ b/launcher/main/updater.c
@@ -12,15 +12,17 @@
 #define DOWNLOAD_LOCATION RG_STORAGE_ROOT "/espgbc/firmware"
 #endif
 
+#define NAMELENGTH 64
+
 typedef struct
 {
-    char name[32];
+    char name[NAMELENGTH];
     char url[256];
 } asset_t;
 
 typedef struct
 {
-    char name[32];
+    char name[NAMELENGTH];
     char date[32];
     asset_t *assets;
     size_t assets_count;
@@ -170,7 +172,7 @@ void updater_show_dialog(void)
         char *name = cJSON_GetStringValue(cJSON_GetObjectItem(release_json, "name"));
         char *date = cJSON_GetStringValue(cJSON_GetObjectItem(release_json, "published_at"));
 
-        snprintf(releases[i].name, 32, "%s", name ?: "N/A");
+        snprintf(releases[i].name, NAMELENGTH, "%s", name ?: "N/A");
         snprintf(releases[i].date, 32, "%s", date ?: "N/A");
 
         cJSON *assets_json = cJSON_GetObjectItem(release_json, "assets");
@@ -186,7 +188,7 @@ void updater_show_dialog(void)
             if (name && url)
             {
                 asset_t *asset = &releases[i].assets[releases[i].assets_count++];
-                snprintf(asset->name, 32, "%s", name);
+                snprintf(asset->name, NAMELENGTH, "%s", name);
                 snprintf(asset->url, 256, "%s", url);
             }
         }


### PR DESCRIPTION
The update file names for the Fri3D Camp 2024 Badge are a bit longer than 32 bytes, as we like to have a long, proper description and also an "OVERWRITES_EVERYTHING" warning to the .img files that contain a fresh copy of the pre-populated FAT storage partition, so that the user knows the storage (including configuration and games) will be overwritten.

Therefore, 32 bytes was a bit short for the update names, and this commit doubles it to 64 bytes.

Of course, if for some reason, a project wants to keep the names short, they can still give them short names, and then the retro-go updater GUI will only show those short names. It's only *if* you want a longer, more descriptive name to be shown, you can now, with this change.