### PR TITLE
i2s audio driver: fix conflict with GPIO0 due to default 0 for .mck_io_num

### DIFF
--- a/components/retro-go/drivers/audio/i2s.c
+++ b/components/retro-go/drivers/audio/i2s.c
@@ -67,6 +67,7 @@ static bool driver_init(int device, int sample_rate)
         if (ret == ESP_OK)
         {
             ret = i2s_set_pin(I2S_NUM_0, &(i2s_pin_config_t) {
+                .mck_io_num = GPIO_NUM_NC,
                 .bck_io_num = RG_GPIO_SND_I2S_BCK,
                 .ws_io_num = RG_GPIO_SND_I2S_WS,
                 .data_out_num = RG_GPIO_SND_I2S_DATA,

--- a/components/retro-go/drivers/audio/i2s.c
+++ b/components/retro-go/drivers/audio/i2s.c
@@ -67,11 +67,13 @@ static bool driver_init(int device, int sample_rate)
         if (ret == ESP_OK)
         {
             ret = i2s_set_pin(I2S_NUM_0, &(i2s_pin_config_t) {
-                .mck_io_num = GPIO_NUM_NC,
                 .bck_io_num = RG_GPIO_SND_I2S_BCK,
                 .ws_io_num = RG_GPIO_SND_I2S_WS,
                 .data_out_num = RG_GPIO_SND_I2S_DATA,
                 .data_in_num = GPIO_NUM_NC
+            #if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(4, 4, 0) // mck_io_num isn't present in esp-idf <= 4.3
+                .mck_io_num = GPIO_NUM_NC, // must be initialized to prevent it from defaulting to 0 (GPIO_NUM_0), which can conflict with other uses of that pin
+            #endif
             });
         }
         if (ret != ESP_OK)

--- a/components/retro-go/drivers/audio/i2s.c
+++ b/components/retro-go/drivers/audio/i2s.c
@@ -67,13 +67,13 @@ static bool driver_init(int device, int sample_rate)
         if (ret == ESP_OK)
         {
             ret = i2s_set_pin(I2S_NUM_0, &(i2s_pin_config_t) {
+            #if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(4, 4, 0) // mck_io_num isn't present in esp-idf <= 4.3
+                .mck_io_num = GPIO_NUM_NC, // must be initialized to prevent it from defaulting to (GPIO_NUM_)0, which would interfere with other uses of that pin
+            #endif
                 .bck_io_num = RG_GPIO_SND_I2S_BCK,
                 .ws_io_num = RG_GPIO_SND_I2S_WS,
                 .data_out_num = RG_GPIO_SND_I2S_DATA,
                 .data_in_num = GPIO_NUM_NC
-            #if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(4, 4, 0) // mck_io_num isn't present in esp-idf <= 4.3
-                .mck_io_num = GPIO_NUM_NC, // must be initialized to prevent it from defaulting to (GPIO_NUM_)0, which would interfere with other uses of that pin
-            #endif
             });
         }
         if (ret != ESP_OK)

--- a/components/retro-go/drivers/audio/i2s.c
+++ b/components/retro-go/drivers/audio/i2s.c
@@ -72,7 +72,7 @@ static bool driver_init(int device, int sample_rate)
                 .data_out_num = RG_GPIO_SND_I2S_DATA,
                 .data_in_num = GPIO_NUM_NC
             #if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(4, 4, 0) // mck_io_num isn't present in esp-idf <= 4.3
-                .mck_io_num = GPIO_NUM_NC, // must be initialized to prevent it from defaulting to 0 (GPIO_NUM_0), which can conflict with other uses of that pin
+                .mck_io_num = GPIO_NUM_NC, // must be initialized to prevent it from defaulting to (GPIO_NUM_)0, which would interfere with other uses of that pin
             #endif
             });
         }


### PR DESCRIPTION
In the i2s_pin_config_t that's passed to i2s_set_pin, .mck_io_num was not initialized to GPIO_NUM_NC, so it defaulted to 0. Which matches the GPIO that the Fri3D Camp 2024 Badge is using for the START button, resulting in "START" being pressed constantly, which caused it to loop through the emulators.