### PR TITLE
Add RG_GPIO_LED_ACTIVE_LOW option

### DIFF
--- a/components/retro-go/rg_system.c
+++ b/components/retro-go/rg_system.c
@@ -887,7 +887,11 @@ void rg_system_set_led(int value)
 {
 #if defined(ESP_PLATFORM) && defined(RG_GPIO_LED)
     if (app.ledValue != value)
+#ifndef RG_GPIO_LED_ACTIVE_LOW
         gpio_set_level(RG_GPIO_LED, value);
+#else
+        gpio_set_level(RG_GPIO_LED, !value);
+#endif
 #endif
     app.ledValue = value;
 }

--- a/components/retro-go/targets/fri3d-2024/config.h
+++ b/components/retro-go/targets/fri3d-2024/config.h
@@ -86,6 +86,7 @@
 
 // Status LED
 #define RG_GPIO_LED                 GPIO_NUM_21
+#define RG_GPIO_LED_ACTIVE_LOW      // setting RG_GPIO_LED low turns on the LED, while high turns it off
 
 // Battery
 #define RG_BATTERY_DRIVER           1


### PR DESCRIPTION
On the Fri3d Camp 2024 badge, the RG_GPIO_LED is active low, meaning it is on when the output is 0/low and off when the output is 3V3/high.

Therefore, we need a way to invert the regular RG_GPIO_LED.

At first I used RG_GPIO_LED_INVERT but that is less descriptive than RG_GPIO_LED_ACTIVE_LOW.