### PR TITLE
updater: improve error handling and cleanup

### DIFF
--- a/launcher/main/updater.c
+++ b/launcher/main/updater.c
@@ -102,22 +102,24 @@ static cJSON *fetch_json(const char *url)
     cJSON *json = NULL;
 
     if (!(req = rg_network_http_open(url, NULL)))
-        goto cleanup;
+        goto cleanup_nothing;
 
     size_t buffer_length = RG_MAX(256 * 1024, req->content_length);
 
     if (!(buffer = calloc(1, buffer_length + 1)))
-        goto cleanup;
+        goto cleanup_http_open;
 
     if (rg_network_http_read(req, buffer, buffer_length) < 16)
-        goto cleanup;
+        goto cleanup_buffer;
 
     if (!(json = cJSON_Parse(buffer)))
-        goto cleanup;
+        RG_LOGI("Fould not parse JSON that was received.");
 
-cleanup:
-    rg_network_http_close(req);
+cleanup_buffer:
     free(buffer);
+cleanup_http_open:
+    rg_network_http_close(req);
+cleanup_nothing:
     return json;
 }
 

--- a/launcher/main/updater.c
+++ b/launcher/main/updater.c
@@ -113,7 +113,7 @@ static cJSON *fetch_json(const char *url)
         goto cleanup_buffer;
 
     if (!(json = cJSON_Parse(buffer)))
-        RG_LOGI("Fould not parse JSON that was received.");
+        RG_LOGI("Could not parse JSON received from releases URL '%s'.", RG_PROJECT_RELEASES_URL);
 
 cleanup_buffer:
     free(buffer);

--- a/launcher/main/updater.c
+++ b/launcher/main/updater.c
@@ -113,7 +113,7 @@ static cJSON *fetch_json(const char *url)
         goto cleanup_buffer;
 
     if (!(json = cJSON_Parse(buffer)))
-        RG_LOGI("Could not parse JSON received from releases URL '%s'.", RG_PROJECT_RELEASES_URL);
+        RG_LOGI("Could not parse JSON received from releases URL '%s'.", url);
 
 cleanup_buffer:
     free(buffer);


### PR DESCRIPTION
I could be off here, but I think there was a bug where, if rg_network_http_open() failed, it would goto "cleanup", which would free that buffer before it had been allocated. It would also do an unnecessary rg_network_http_close() on NULL but that is allowed.

Fun fact: these elegant "fall through" cleanup styles are used all over the Linux kernel and goes a bit contrary to the common "goto is bad and you should never use it" conventions :-)