### PR TITLE
Add HTTP POST support to the HTTP client

### DIFF
--- a/components/retro-go/rg_network.c
+++ b/components/retro-go/rg_network.c
@@ -255,10 +255,10 @@ bool rg_network_init(void)
     TRY(esp_wifi_init(&cfg));
     TRY(esp_wifi_set_storage(WIFI_STORAGE_RAM));
 
-    // Setup SNTP client but don't query it yet
+    // Setup SNTP client
     esp_sntp_setoperatingmode(SNTP_OPMODE_POLL);
     esp_sntp_setservername(0, "pool.ntp.org");
-    // esp_sntp_init();
+    // esp_sntp_init(); // don't query it yet (do it when IP_EVENT_STA_GOT_IP)
 
     // Tell rg_network_get_info() that we're enabled but not yet connected
     network.state = RG_NETWORK_DISCONNECTED;

--- a/components/retro-go/rg_network.c
+++ b/components/retro-go/rg_network.c
@@ -306,6 +306,7 @@ try_again:
 
     req->status_code = esp_http_client_get_status_code(http_client);
     req->content_length = esp_http_client_get_content_length(http_client);
+    RG_LOGI("HTTP request got status code: %d and content length: %d", req->status_code, req->content_length);
     req->client = (void *)http_client;
 
     if (req->status_code == 301 || req->status_code == 302)

--- a/components/retro-go/rg_network.h
+++ b/components/retro-go/rg_network.h
@@ -40,7 +40,7 @@ rg_network_t rg_network_get_info(void);
 
 typedef struct
 {
-
+    char *post_data; // if post_data is provided, the http client will do a POST request with that data
 } rg_http_cfg_t;
 
 typedef struct


### PR DESCRIPTION
I'm using this for of my (experimental, but working!) ["find games" functionality](https://github.com/tomvanbraeckel/retro-go-fri3d/tree/find-games), where one retro-go device connects to another's wifi hotspot and recursively "finds" (and downloads) ROMs that it doesn't have yet.

The idea is that kids can easily share games with each other this way, especially self-made GameBoy Color games as it looks like there will be a GBStudio workshop at Fri3d camp!

I'm thinking of giving the users a high-level choice of which ROM folders to check (/sd/roms/ or /sd/roms/gbc/ or /sd/roms/nes or /sd/roms/gb or /sd/roms/doom etc) to make it faster and more selective, in case there are many games.

Even better would be to to create a nice new "remote file browser" tab that properly allows you to browse another retro-go's (or in general. any webserver's) files. This could use the default http://192.168.4.1/ (assuming you're connected to another retro-go's wifi hotspot) but it would be nice to have some way of configuring this URL. So a method of entering an IP address or generic text on the retro-go would be cool... dream, dream, dream!