### PR TITLE
Add default IP hint in access point settings

### DIFF
--- a/launcher/main/wifi.c
+++ b/launcher/main/wifi.c
@@ -92,7 +92,7 @@ static rg_gui_event_t wifi_access_point_cb(rg_gui_option_t *option, rg_gui_event
 {
     if (event == RG_DIALOG_ENTER)
     {
-        if (rg_gui_confirm("Wi-Fi AP", "Start access point?\n\nSSID: retro-go\nPassword: retro-go", true))
+        if (rg_gui_confirm("Wi-Fi AP", "Start access point?\n\nSSID: retro-go\nPassword: retro-go\n\nBrowse: http://192.168.4.1/", true))
         {
             rg_network_wifi_stop();
             rg_network_wifi_set_config(&(const rg_wifi_config_t){


### PR DESCRIPTION
Currently, it's not easy for a novice user to find the retro-go's IP address when it's in access point mode. They have to enable the access point, then find and read the documentation, which states they have to go into the "Debug Menu". Then they have to find said "Debug Menu", locate the IP address in the list, and then prefix it with http:// - not https:// as some modern browsers (like Firefox) have recently started defaulting to.

Note that enabling the wifi access point itself is hardly a "debug" action. Rather, it's a pretty standard way to manage the files on the device and configure it. On devices without an SD card, it's pretty much the *only* way to configure the device.

So to make this easier, it makes sense to display the retro-go management URL more prominently at the moment the user is about to enable the access point.

While the IP address of the retro-go in access point mode could vary in principle, the espressif FAQ states that: "The default network segment used by ESP8266 [and ESP32] SoftAP is 192.168.4.*, and its IP address is 192.168.4.1".

So it's reasonable to assume the IP address will indeed be 192.168.4.1.

If the default doesn't work, because for some reason a future ESP-IDF release uses a different IP address (unlikely?) then they can still go into the debug menu to check the actual IP address and use that one. And then this hint that's provided in the UI would need to be removed, or changed.