### PR TITLE
Instructions to Patch retro-go for custom hardware

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -1,9 +1,12 @@
 # Building Retro-Go
 
+
 ## Prerequisites
 You will need a working installation of [esp-idf](https://docs.espressif.com/projects/esp-idf/en/release-v4.3/esp32/get-started/index.html#get-started-get-prerequisites). Versions 4.3 to 5.2 are supported.
 
+
 _Note: As of retro-go 1.35, I use 4.3. Version 4.1 was used for 1.20 to 1.34 versions._
+
 
 ### ESP-IDF Patches
 Patching esp-idf may be required for full functionality. Patches are located in `tools/patches` and can be applied to your global esp-idf installation, they will not break your other projects/devices.
@@ -11,34 +14,62 @@ Patching esp-idf may be required for full functionality. Patches are located in 
 - `panic-hook`: This is to help users report bugs, see `Capturing crash logs` below for more details. The patch is optional but recommended.
 
 
+
+
 ## Obtaining the code
 
+
 Using git is the preferred method but you can also download a zip from the project's front page and extract it if you want, Retro-Go has no external dependencies.
+
 
 There are generally two active git branches on retro-go:
 - `master` contains the code form the most recent release and is usually tested and known to be working
 - `dev` contains code in development that will be merged to master upon the next release and is often untested
 
+
 `git clone -b <branch> https://github.com/ducalex/retro-go/`
+
+
 
 
 ## Build everything and generate .fw:
 - Generate a .fw file to be installed with odroid-go-firmware (SD Card):\
-    `python rg_tool.py build-fw` or `python rg_tool.py release` (clean build)
+   `python rg_tool.py build-fw` or `python rg_tool.py release` (clean build)
 - Generate a .img to be flashed with esptool.py (Serial):\
-    `python rg_tool.py build-img` or `python rg_tool.py release` (clean build)
+   `python rg_tool.py build-img` or `python rg_tool.py release` (clean build)
+
 
 For a smaller build you can also specify which apps you want, for example the launcher + DOOM only:
 1. `python rg_tool.py build-fw launcher prboom-go`
 
+
 Note that the app named `retro-core` contains the following emulators: NES, PCE, G&W, Lynx, and SMS/GG/COL. As such, these emulators cannot be selected individually. The reason for the bundling is simply size, together they account for a mere 700KB instead of almost 3MB when they were built separately.
 
 
+
+
 ## Build, flash, and monitor individual apps for faster development:
+(**not for `.img`**s, see below)
+
+
 It would be tedious to build, move to SD, and flash a full .fw all the time during development. Instead you can:
 1. Flash: `python rg_tool.py --port=COM3 flash prboom-go`
 2. Monitor: `python rg_tool.py --port=COM3 monitor prboom-go`
 3. Flash then monitor: `python rg_tool.py --port=COM3 run prboom-go`
+
+
+## Flashing for `.img`s
+
+
+# Flashing
+Once we have a `.img`, we can use `./rg_tool` to flash it to the device. Other tools like `esptool` need specific arguments, which `rg_tool` handles for us.
+
+
+To flash an image, run
+```
+./rg_tool install (apps) --target (target)
+```
+You can also specify the USB port with the `--port` argument
 
 
 ## Environment variables
@@ -48,21 +79,33 @@ rg_tool.py supports a few environment variables if you want to avoid passing fla
 - `RG_TOOL_PORT` represents --port
 
 
+
+
 ## Changing the launcher's images
-All images used by the launcher (headers, logos) are located in `launcher/main/images`. If you edit them you must run the `launcher/main/gen_images.py` script to regenerate `images.c`. Magenta (rgb(255, 0, 255) / 0xF81F) is used as the transparency colour.
+All images used by the launcher (headers, logos) are located in `launcher/main/images`. If you edit them you must run the `launcher/main/gen_images.py` script to regenerate `images.c`. Magenta (rgb(255, 0, 255) / 0xF81F) is used as the transparency color.
+
+
 
 
 ## Capturing crash logs
 When a panic occurs, Retro-Go has the ability to save debugging information to `/sd/crash.log`. This provides users with a simple way of recovering a backtrace (and often more) without having to install drivers and serial console software. A weak hook is installed into esp-idf panic's putchar, allowing us to save each chars in RTC RAM. Then, after the system resets, we can move that data to the sd card. You will find a small esp-idf patch to enable this feature in tools/patches.
 
+
 To resolve the backtrace you will need the application's elf file. If lost, you can recreate it by building the app again **using the same esp-idf and retro-go versions**. Then you can run `xtensa-esp32-elf-addr2line -ifCe app-name/build/app-name.elf`.
 
 
+
+
 ## Porting
-I don't want to maintain non-ESP32 ports in this repository but let me know if I can make small changes to make your own port easier! The absolute minimum requirements for Retro-Go are roughly:
+I don't want to maintain non-ESP32 ports in this repository, but let me know if I can make small changes to make your own port easier! The absolute minimum requirements for Retro-Go are roughly:
 - Processor: 200Mhz 32bit little-endian
 - Memory: 2MB
 - Compiler: C99 (and C++03 for handy-go)
 
+
 Whilst all applications were heavily modified or even redesigned for our constrained needs, special care is taken to keep
 Retro-Go and ESP32-specific code exclusively in their port file (main.c). This makes reusing them in your own codebase very easy!
+
+
+For other ESP32 setups, refer to [PATCHING.md](PATCHING.md)
+

--- a/PATCHING.md
+++ b/PATCHING.md
@@ -56,8 +56,9 @@ First, change `RG_TARGET_NAME` to match the name of your target folder.
 
 
 Most of it, you will need to figure out the correct parameters for (eg. Storage and Audio)
+
 **Display**
-___
+
 If you aren't using the ILI9341 screen driver, you will need to change the `SCREEN_DRIVER` parameter. (Otherwise, just change the following settings and continue).
 
 
@@ -87,12 +88,11 @@ Make this driver in `components/retro-go/drivers/display`
 
 ___
 **Input**
-___
+
 Back in `config.h`, you will see the configuration for an I2C gamepad. If you aren't using that, you can make your own parameters based on the existing input forms in `components/retro-go/rg_input.c`
 
 
 You can also write your own input driver for unique input forms. Just look at the existing code in `rg_input.c` and match that
-___
 
 
 

--- a/PATCHING.md
+++ b/PATCHING.md
@@ -1,0 +1,129 @@
+# Patching Retro-Go
+Adjust retro-go to use your drivers and hardware
+
+
+
+
+# Prerequisites
+You will need a working installation of [esp-idf](https://docs.espressif.com/projects/esp-idf/en/release-v4.3/esp32/get-started/index.html#get-started-get-prerequisites). Versions 4.3 to 5.2 are supported.
+
+
+Before using your own patch of retro-go, make a clean build of retro go using bare configurations
+```
+./rg_tool.py build-img launcher --target esp32s3-devkit-c
+```
+Make sure that build successfully before continuing.  If it doesn't, refer to [BUILDING.md](BUILDING.md). Also check your `esp-idf` installation and make sure you have it set up in your environment (run `idf.py --version` to check)
+
+
+# rg_tool
+ESP-IDF doesn't support managing multiple apps in one environment (launcher, prboom-go, etc). `rg_tool.py` is used instead, which passes correct arguments to `idf.py` and other tools.
+
+
+To get started, run
+```
+./rg_tool.py
+```
+
+
+Since we aren't using other setups, like ODROID-GO, we will be building `/img` files, not `.fw`. Use `./rg_tool.py build-img` to build imgs.
+
+
+**Make sure a basic setup is working before continuing to patch the code for your setup**
+```
+./rg_tool.py build-img launcher --target esp32s3-devkit-c
+```
+
+
+# Patching
+Retro-Go uses reusable hardware components, so it is easy to set it up for your own hardware.
+
+
+You will find the targets (configs for each device) in `components/retro-go/targets`
+
+
+To make a base one, copy `esp32s3-devkit-c` and rename it.
+
+
+## config.h
+
+
+`config.h` has the bulk of your configurations.
+
+
+First, change `RG_TARGET_NAME` to match the name of your target folder.
+
+
+
+
+Most of it, you will need to figure out the correct parameters for (eg. Storage and Audio)
+**Display**
+___
+If you aren't using the ILI9341 screen driver, you will need to change the `SCREEN_DRIVER` parameter. (Otherwise, just change the following settings and continue).
+
+
+(You will find more display configuration in the `SPI Display` section below)
+
+
+For now, only the ILI9341 is included. Increment the number. Then in `components/retro-go/rg_display.c`, find this part
+```
+#if RG_SCREEN_DRIVER == 0 /* ILI9341 */
+#include "drivers/display/ili9341.h"
+#elif RG_SCREEN_DRIVER == 99
+#include "drivers/display/sdl2.h"
+#else
+#include "drivers/display/dummy.h"
+#endif
+```
+
+
+Add a `#elif` for your SCREEN_DRIVER. In the body, use `#include "drivers/display/(YOUR DISPLAY DRIVER).h"` (eg. `st7789.h`).
+
+
+You will need to create that file for your display. Unfortunately, there is no one-for-all way to make this. It will need the same template as the other display drivers there, but it will differ for each display. To start, check the Retro-Go issues on GitHub and try searching on Google.
+
+
+Make this driver in `components/retro-go/drivers/display`
+
+
+___
+**Input**
+___
+Back in `config.h`, you will see the configuration for an I2C gamepad. If you aren't using that, you can make your own parameters based on the existing input forms in `components/retro-go/rg_input.c`
+
+
+You can also write your own input driver for unique input forms. Just look at the existing code in `rg_input.c` and match that
+___
+
+
+
+
+### sdkconfig
+`sdkconfig` is used by ESP-IDF to build the code for the ESP32 itself. It is hard to manually write it all out, so you can use `menuconfig`
+
+
+For this, go back to your root folder. Build the launcher for your target (this will make sure you have the correct ESP32 board selected).
+```
+./rg_tool.py clean
+./rg_tool.py build launcher --target (YOUR TARGET)
+```
+
+
+Then `cd` into `launcher` and run `idf.py menuconfig`. Navigate to Serial Flasher Config and adjust it all to your board. Make sure to save the changes and exit.
+
+
+Use this generated sdkconfig in your target with
+```
+cd ..
+mv  -f launcher/sdkconfig components/retro-go/targets/retrotoids/sdkconfig
+```
+This will configure ESP-IDF to run on your board
+
+
+### env.py
+
+
+Change the target board in `env.py` to match yours
+
+
+After completing all these steps, you should be able to build your apps with `rg_tool`. See `BUILDING.md` for more info about this and flashing. **Make sure to use the steps for `.img`, NOT `.fw`**
+

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 - [Building](#building)
 - [Acknowledgements](#acknowledgements)
 - [License](#license)
+- [Custom Hardware](#custom-hardware)
 
 # Description
 Retro-Go is a firmware to play retro games on ESP32-based devices (officially supported are

--- a/README.md
+++ b/README.md
@@ -12,7 +12,9 @@
 Retro-Go is a firmware to play retro games on ESP32-based devices (officially supported are
 ODROID-GO and MRGC-G32). The project consists of a launcher and half a dozen applications that
 have been heavily optimized to reduce their cpu, memory, and flash needs without reducing
-compatibility!
+compatibility! 
+
+Get started in [BUILDING.md](BUILDING.md)
 
 ### Supported systems:
 - Nintendo: **NES, SNES (slow), Gameboy, Gameboy Color, Game & Watch**
@@ -167,7 +169,16 @@ Instructions moved to [THEMING.md](THEMING.md).
 
 
 # Building
-Instructions moved to [BUILDING.md](BUILDING.md).
+To build `retro-go`, you'll need ESP-IDF (v4.3-5.2) and may need to apply patches for full functionality. 
+
+The code can be obtained via Git, and you can build firmware or individual apps using the `rg_tool.py` script.
+
+Read more in [BUILDING.md](BUILDING.md).
+
+# Custom Hardware
+You can build retro-go for your own custom setup that isn't already configured. All you need to do is make a new target and include your drivers.
+
+Get started in [PATCHING.md](PATCHING.md)
 
 
 # Acknowledgements


### PR DESCRIPTION
This creates `PATCHING.md`, which adds a lot of instructions for customizing retro-go and its configurations and drivers. It also creates some links from BUILDING and README.

Most of these are from my experience in #110 

PATCHING.md shows how to create a new target, make new display drivers, modify `rg_input` for unique input forms, generate `sdkconfig` and more!