### PR TITLE
Fixes ledc_timer freq_hz

### DIFF
--- a/components/retro-go/drivers/audio/buzzer.c
+++ b/components/retro-go/drivers/audio/buzzer.c
@@ -214,7 +214,7 @@ static bool buzzer_init(int device, int sampleRate)
 
     ledc_timer_config_t ledc_timer = {
         .duty_resolution = pwm_resolution,
-        .freq_hz = NOTE_A,
+        .freq_hz = freq,
         .speed_mode = LEDC_PWM_SPEED_MODE,
         .timer_num = LEDC_PWM_TIMER,
         .clk_cfg = LEDC_USE_APB_CLK,


### PR DESCRIPTION
Not sure what the intention was, but the freq_hz should be the calculated frequency for the sample rate and MAX_AUDIBLE_NOTE