### PR TITLE
Clean up runner in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,22 +7,19 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        app: [updater, launcher, retro-core, prboom-go, snes9x, gwenesis, fmsx, gbsp]
+      fail-fast: false
 
     steps:
-    # Remove ~18 GiB of preinstalled software to have more disk space during the build
-    - name: Cleanup runner
-      run: |
-        df -h
-        sudo rm -rf /opt/microsoft /usr/local/.ghcup /usr/local/julia* /usr/share/dotnet /usr/share/swift /usr/lib/llvm*
-        df -h
-
     - name: Checkout repository
       uses: actions/checkout@v4
 
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3
 
-    - name: Build
+    - name: Build app
       uses: docker/build-push-action@v6
       with:
         context: .
@@ -30,13 +27,63 @@ jobs:
         cache-from: type=gha
         cache-to: type=gha,mode=max
         load: true
+        build-args: |
+          APPS=${{ matrix.app }}
 
-    - name: Extract binaries from docker image
+    - name: Extract app binary
       run: |
-        docker run --rm -v $(pwd)/build:/build retro-go:latest sh -c "cp /app/*.fw /build"
+        mkdir -p build
+        docker run --rm -v $(pwd)/build:/build retro-go:latest sh -c "cp /app/${{ matrix.app }}/build/${{ matrix.app }}.bin /build/"
+
+    - name: Upload app binary
+      uses: actions/upload-artifact@v4
+      with:
+        name: app-${{ matrix.app }}
+        path: build/*.bin
+
+  pack:
+    needs: build
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
+    - name: Download all app binaries
+      uses: actions/download-artifact@v4
+      with:
+        pattern: app-*
+        path: build
+        merge-multiple: false
+
+    - name: Copy binaries to app directories
+      run: |
+        for app in updater launcher retro-core prboom-go snes9x gwenesis fmsx gbsp; do
+          mkdir -p $app/build
+          cp build/app-$app/*.bin $app/build/
+        done
+
+    - name: Build and pack firmware
+      uses: docker/build-push-action@v6
+      with:
+        context: .
+        tags: retro-go:latest
+        cache-from: type=gha
+        cache-to: type=gha,mode=max
+        load: true
+        build-args: |
+          APPS=none
+
+    - name: Extract firmware from docker image
+      run: |
+        mkdir -p output
+        docker run --rm -v $(pwd)/output:/output retro-go:latest sh -c "cp /app/*.fw /output/"
 
     - name: Upload artifacts
       uses: actions/upload-artifact@v4
       with:
         name: binaries
-        path: build/*.fw
+        path: output/*.fw

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,8 @@
 FROM espressif/idf:release-v5.1
 
+# Build argument to specify which apps to build (space-separated, or "none" to skip build and only pack)
+ARG APPS=updater launcher retro-core prboom-go snes9x gwenesis fmsx gbsp
+
 WORKDIR /app
 
 ADD . /app
@@ -13,5 +16,10 @@ RUN cd /opt/esp/idf && \
 
 # Build
 SHELL ["/bin/bash", "-c"]
-RUN . /opt/esp/idf/export.sh && \
-	python rg_tool.py --target=odroid-go release
+# Build apps (if APPS is not "none"), then pack firmware
+RUN if [ "$APPS" != "none" ]; then \
+      . /opt/esp/idf/export.sh && \
+      python rg_tool.py --target=odroid-go build $APPS; \
+    fi && \
+    . /opt/esp/idf/export.sh && \
+    python rg_tool.py --target=odroid-go build-fw


### PR DESCRIPTION
# What

Clean up some directories in the GitHub action runner in order to have more space during the build.

# Why

After upgrading to the espressif 5.1 Docker image CI is failing due to a "out of disk space" error.
To address the issue we looked at what was in the file system that we didn't need (we don't really need anything other than docker) and identified large and quick to delete directories in order to create space while avoiding the introduction of a long delay at the beginning of the jobs.

# Test

- [Run with this change](https://github.com/TomzxForks/retro-go/actions/runs/20945280839/job/60186999660)