### PR TITLE
Clean up runner in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
 name: ci
 
-on: 
+on:
   workflow_dispatch:      # Start a workflow
   push:
 
@@ -9,6 +9,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+    # Remove ~18 GiB of preinstalled software to have more disk space during the build
+    - name: Cleanup runner
+      run: |
+        df -h
+        sudo rm -rf /opt/microsoft /usr/local/.ghcup /usr/local/julia* /usr/share/dotnet /usr/share/swift /usr/lib/llvm*
+        df -h
+
     - name: Checkout repository
       uses: actions/checkout@v4
 


### PR DESCRIPTION
# What

Clean up some directories in the GitHub action runner in order to have more space during the build.

# Why

After upgrading to the espressif 5.1 Docker image CI is failing due to a "out of disk space" error.
To address the issue we looked at what was in the file system that we didn't need (we don't really need anything other than docker) and identified large and quick to delete directories in order to create space while avoiding the introduction of a long delay at the beginning of the jobs.

# Test

- [Run with this change](https://github.com/TomzxForks/retro-go/actions/runs/20945280839/job/60186999660)