### PR TITLE
Simple gamma correction for display

### DIFF
--- a/components/retro-go/rg_display.c
+++ b/components/retro-go/rg_display.c
@@ -505,7 +505,7 @@ void rg_display_set_backlight(display_backlight_t percent)
 {
     config.backlight = RG_MIN(RG_MAX(percent, RG_DISPLAY_BACKLIGHT_MIN), RG_DISPLAY_BACKLIGHT_MAX);
     rg_settings_set_number(NS_GLOBAL, SETTING_BACKLIGHT, config.backlight);
-    lcd_set_backlight(config.backlight);
+    lcd_set_backlight(config.backlight*config.backlight/100.0f);//Gamma = 2
 }
 
 display_backlight_t rg_display_get_backlight(void)

--- a/components/retro-go/rg_display.h
+++ b/components/retro-go/rg_display.h
@@ -32,7 +32,7 @@ typedef enum
 
 typedef enum
 {
-    RG_DISPLAY_BACKLIGHT_MIN = 1,
+    RG_DISPLAY_BACKLIGHT_MIN = 10,
     RG_DISPLAY_BACKLIGHT_MAX = 100,
 } display_backlight_t;
 

--- a/components/retro-go/rg_gui.c
+++ b/components/retro-go/rg_gui.c
@@ -1464,10 +1464,8 @@ static rg_gui_event_t brightness_update_cb(rg_gui_option_t *option, rg_gui_event
     if (event == RG_DIALOG_NEXT)
         level += 10;
 
-    level -= (level % 10);
-
     if (level != prev_level)
-        rg_display_set_backlight(RG_MAX(level, 1));
+        rg_display_set_backlight(RG_MAX(level, RG_DISPLAY_BACKLIGHT_MIN));
 
     sprintf(option->value, "%d%%", rg_display_get_backlight());
 


### PR DESCRIPTION
Second try for this pull request. This time directly based on the dev branch. 

# Description
This PR improves the display backlight experience by addressing the non-linear nature of human brightness perception.

# Changes:
- Gamma Correction: Implemented a simple gamma correction (gamma = 2) in `rg_display.c`. This ensures that brightness steps feel visually more uniform to the user.
- Sanity Checks: New minimum of 10 % brightness instead of 1 % brightness so the intervals are always 10 %. 

# Why?
Human eyes are more sensitive to changes in dark areas than in bright ones. A linear PWM duty cycle feels "jumpy" at low levels and shows almost no visible change at high levels. Gamma correction fixes this.