### PR TITLE
Volume quadratic and volume steps of 10.

### DIFF
--- a/components/retro-go/rg_audio.c
+++ b/components/retro-go/rg_audio.c
@@ -194,7 +194,7 @@ void rg_audio_set_volume(int percent)
     RG_ASSERT(audio.driver != NULL, "Audio device not ready!");
     audio.volume = RG_MIN(RG_MAX(percent, 0), 100);
     if (audio.driver->set_volume)
-        audio.driver->set_volume(audio.volume);
+        audio.driver->set_volume((audio.volume*audio.volume)/100);
     rg_settings_set_number(NS_GLOBAL, SETTING_VOLUME, audio.volume);
     RG_LOGI("Volume set to %d%%\n", audio.volume);
 }

--- a/components/retro-go/rg_gui.c
+++ b/components/retro-go/rg_gui.c
@@ -1440,11 +1440,11 @@ static rg_gui_event_t volume_update_cb(rg_gui_option_t *option, rg_gui_event_t e
     int prev_level = level;
 
     if (event == RG_DIALOG_PREV)
-        level -= 5;
+        level -= 10;
     if (event == RG_DIALOG_NEXT)
-        level += 5;
+        level += 10;
 
-    level -= (level % 5);
+    level -= (level % 10);
 
     if (level != prev_level)
         rg_audio_set_volume(level);


### PR DESCRIPTION
Similar to "Simple gamma correction for display#293" but for sound.

# Description
This PR improves the sound experience by addressing the non-linear nature of human volume perception.

# Changes:
- Volume is still giving in percent, but the value is squared and divided by 100. Thus the user can do fines changes at low volumes and at high volumes changes still have an impact.
- The intervals are steps of 10 %. Seems sufficient and 5 % would complicate things as audio.volume is an int, not a float. 