### PR TITLE
Moving average with more samples for battery ADC

### DIFF
--- a/components/retro-go/rg_input.c
+++ b/components/retro-go/rg_input.c
@@ -158,15 +158,19 @@ bool rg_input_read_battery_raw(rg_battery_t *out)
     bool present = true;
     bool charging = false;
 
-#if RG_BATTERY_DRIVER == 1 /* ADC */
-    for (int i = 0; i < 4; ++i)
-    {
-        int value = _adc_get_voltage(RG_BATTERY_ADC_UNIT, RG_BATTERY_ADC_CHANNEL);
-        if (value < 0)
-            return false;
-        raw_value += value;
+#if RG_BATTERY_DRIVER == 1 /* ADC */    
+    static uint16_t history[16];
+    static int history_idx = 0;
+
+    int current_v = _adc_get_voltage(RG_BATTERY_ADC_UNIT, RG_BATTERY_ADC_CHANNEL);
+
+    history[history_idx] = (uint32_t)current_v;
+    history_idx = (history_idx + 1) % 16;
+
+    for (int i = 0; i < 16; ++i){
+        raw_value += history[i];
     }
-    raw_value /= 4;
+    raw_value = raw_value >> 4;
 #elif RG_BATTERY_DRIVER == 2 /* I2C */
     uint8_t data[5];
     if (!rg_i2c_read(0x20, -1, &data, 5))

--- a/components/retro-go/rg_input.c
+++ b/components/retro-go/rg_input.c
@@ -161,16 +161,28 @@ bool rg_input_read_battery_raw(rg_battery_t *out)
 #if RG_BATTERY_DRIVER == 1 /* ADC */    
     static uint16_t history[16];
     static int history_idx = 0;
+    static int flag = 0;
 
     int current_v = _adc_get_voltage(RG_BATTERY_ADC_UNIT, RG_BATTERY_ADC_CHANNEL);
 
-    history[history_idx] = (uint32_t)current_v;
+    history[history_idx] = (uint16_t)current_v;
     history_idx = (history_idx + 1) % 16;
 
-    for (int i = 0; i < 16; ++i){
-        raw_value += history[i];
+    if (flag){
+        for (int i = 0; i < 16; ++i){
+            raw_value += history[i];
+        }
+        raw_value = raw_value >> 4;
     }
-    raw_value = raw_value >> 4;
+    else{
+        for (int i = 0; i < history_idx; ++i){
+            raw_value += history[i];
+        }
+        raw_value /= history_idx;
+        if (history_idx == 15){
+            flag = 1;
+        }
+    }
 #elif RG_BATTERY_DRIVER == 2 /* I2C */
     uint8_t data[5];
     if (!rg_i2c_read(0x20, -1, &data, 5))

--- a/components/retro-go/rg_system.c
+++ b/components/retro-go/rg_system.c
@@ -463,10 +463,12 @@ rg_app_t *rg_system_init(const rg_config_t *config)
     rg_storage_init();
     rg_input_init();
 
+#if RG_BATTERY_DRIVER == 1 /* ADC */ 
     for (int i = 0; i < 16; i++) {
         rg_input_read_battery_raw(NULL);
         rg_task_delay(5);
     }
+#endif
 
     // Test for recovery request as early as possible
     for (int timeout = 5, btn; (btn = rg_input_read_gamepad() & RG_RECOVERY_BTN) && timeout >= 0; --timeout)

--- a/components/retro-go/rg_system.c
+++ b/components/retro-go/rg_system.c
@@ -463,13 +463,6 @@ rg_app_t *rg_system_init(const rg_config_t *config)
     rg_storage_init();
     rg_input_init();
 
-#if RG_BATTERY_DRIVER == 1 /* ADC */ 
-    for (int i = 0; i < 16; i++) {
-        rg_input_read_battery_raw(NULL);
-        rg_task_delay(5);
-    }
-#endif
-
     // Test for recovery request as early as possible
     for (int timeout = 5, btn; (btn = rg_input_read_gamepad() & RG_RECOVERY_BTN) && timeout >= 0; --timeout)
     {

--- a/components/retro-go/rg_system.c
+++ b/components/retro-go/rg_system.c
@@ -463,6 +463,11 @@ rg_app_t *rg_system_init(const rg_config_t *config)
     rg_storage_init();
     rg_input_init();
 
+    for (int i = 0; i < 16; i++) {
+        rg_input_read_battery_raw(NULL);
+        rg_task_delay(5);
+    }
+
     // Test for recovery request as early as possible
     for (int timeout = 5, btn; (btn = rg_input_read_gamepad() & RG_RECOVERY_BTN) && timeout >= 0; --timeout)
     {


### PR DESCRIPTION
The battery ADC is pretty jumpy, so more measurements are necessary to have a stable value (oversampling). As ADC measurements take some time, a lot of them slow the system. I reduced the measurements from 4 to 1 (speed increase), but included a history of 16 samples. This history has to be filled at startup, thus rg_system.c had also to be updated.

Changes in voltage now take longer to get recognized, but battery voltage changes are usually quite slow.