### PR TITLE
Add support for RG_GPIO_SND_I2S_MCK for audio

### DIFF
--- a/components/retro-go/drivers/audio/i2s.c
+++ b/components/retro-go/drivers/audio/i2s.c
@@ -78,7 +78,11 @@ static bool driver_init(int device, int sample_rate)
         if (ret == ESP_OK)
         {
             ret = i2s_set_pin(I2S_NUM_0, &(i2s_pin_config_t) {
+            #ifdef RG_GPIO_SND_I2S_MCK
+                .mck_io_num = RG_GPIO_SND_I2S_MCK,
+            #else
                 .mck_io_num = GPIO_NUM_NC,
+            #endif
                 .bck_io_num = RG_GPIO_SND_I2S_BCK,
                 .ws_io_num = RG_GPIO_SND_I2S_WS,
                 .data_out_num = RG_GPIO_SND_I2S_DATA,


### PR DESCRIPTION
Some DAC devices, like the ultra-affordable CJC4334H DAC which will be used on the upcoming [Fri3d Camp 2026 Badge](https://github.com/Fri3dCamp/badge_2026_hw), need a Master Clock.

Luckily, the esp-idf's i2s driver fully supports this, so all that's needed is this super simple PR to allow targets to optionally define a MCK (Master Clock) for their I2S devices, instead of always setting it to GPIO_NUM_NC.