### PR TITLE
New GPIO driver: CH32X035-based

### DIFF
--- a/components/retro-go/rg_i2c.c
+++ b/components/retro-go/rg_i2c.c
@@ -181,6 +181,15 @@ static const _gpio_sequence gpio_init_seq[] = {};
 static const _gpio_sequence gpio_deinit_seq[] = {};
 static rg_gpio_mode_t PCF857x_mode = -1;
 
+#elif RG_I2C_GPIO_DRIVER == 6 // CH32X035 (Fri3D 2026 expander)
+
+static const _gpio_port gpio_ports[] = {
+    {0x04, -1, -1, -1}, // PORT 0 (button states low byte)
+    {0x05, -1, -1, -1}, // PORT 1 (button states high byte)
+};
+static const _gpio_sequence gpio_init_seq[] = {};
+static const _gpio_sequence gpio_deinit_seq[] = {};
+
 #else
 
 #error "Unknown I2C GPIO Extender driver type!"
@@ -258,6 +267,10 @@ bool rg_i2c_gpio_configure_port(int port, uint8_t mask, rg_gpio_mode_t mode)
         return rg_i2c_write(gpio_address, -1, &temp, gpio_ports_count)
             && rg_i2c_read(gpio_address, -1, &temp, gpio_ports_count);
     return rg_i2c_write(gpio_address, -1, &gpio_output_values, gpio_ports_count);
+#elif RG_I2C_GPIO_DRIVER == 6 // CH32X035 (Fri3D 2026 expander)
+    (void)mask;
+    (void)mode;
+    return true;
 #else
     int direction_reg = gpio_ports[port].direction_reg;
     int pullup_reg = gpio_ports[port].pullup_reg;
@@ -274,6 +287,9 @@ int rg_i2c_gpio_read_port(int port)
 #if RG_I2C_GPIO_DRIVER == 4 || RG_I2C_GPIO_DRIVER == 5 // PCF8575/PCF8574
     uint8_t values[gpio_ports_count];
     return rg_i2c_read(gpio_address, -1, &values, gpio_ports_count) ? values[port] : -1;
+#elif RG_I2C_GPIO_DRIVER == 6 // CH32X035 (Fri3D 2026 expander)
+    uint8_t values[2];
+    return rg_i2c_read(gpio_address, gpio_ports[0].input_reg, &values, sizeof(values)) ? values[port] : -1;
 #else
     return rg_i2c_read_byte(gpio_address, gpio_ports[port].input_reg);
 #endif
@@ -288,6 +304,9 @@ bool rg_i2c_gpio_write_port(int port, uint8_t value)
     if (PCF857x_mode != RG_GPIO_OUTPUT)
         return true; // This is consistent with other extenders, where the output latch is updated even in input mode
     return rg_i2c_write(gpio_address, -1, &gpio_output_values, gpio_ports_count);
+#elif RG_I2C_GPIO_DRIVER == 6 // CH32X035 (Fri3D 2026 expander)
+    (void)value;
+    return true; // outputs are controlled via dedicated registers, not a GPIO latch
 #else
     return rg_i2c_write_byte(gpio_address, gpio_ports[port].output_reg, value);
 #endif

--- a/components/retro-go/targets/byteboi-rev1/config.h
+++ b/components/retro-go/targets/byteboi-rev1/config.h
@@ -10,7 +10,7 @@
 // #define RG_STORAGE_FLASH_PARTITION  "vfs"
 
 // GPIO Extender
-#define RG_I2C_GPIO_DRIVER          2   // 1 = AW9523, 2 = PCF9539, 3 = MCP23017
+#define RG_I2C_GPIO_DRIVER          2   // 1 = AW9523, 2 = PCF9539, 3 = MCP23017, 6 = CH32X035
 #define RG_I2C_GPIO_ADDR            0x74
 
 // Audio

--- a/components/retro-go/targets/esp32-p4-devkit/config.h
+++ b/components/retro-go/targets/esp32-p4-devkit/config.h
@@ -20,7 +20,7 @@
 /****************************************************************************
  * I2C / GPIO Extender                                                      *
  ****************************************************************************/
-// #define RG_I2C_GPIO_DRIVER          0   // 1 = AW9523, 2 = PCF9539, 3 = MCP23017, 4 = PCF8575
+// #define RG_I2C_GPIO_DRIVER          0   // 1 = AW9523, 2 = PCF9539, 3 = MCP23017, 4 = PCF8575, 6 = CH32X035
 // #define RG_I2C_GPIO_ADDR            0x00
 // #define RG_GPIO_I2C_SDA             GPIO_NUM_15
 // #define RG_GPIO_I2C_SCL             GPIO_NUM_4

--- a/components/retro-go/targets/esp32-s3-devkit/config.h
+++ b/components/retro-go/targets/esp32-s3-devkit/config.h
@@ -15,7 +15,7 @@
 /****************************************************************************
  * I2C / GPIO Extender                                                      *
  ****************************************************************************/
-// #define RG_I2C_GPIO_DRIVER          0   // 1 = AW9523, 2 = PCF9539, 3 = MCP23017, 4 = PCF8575, 5 = PCF8574
+// #define RG_I2C_GPIO_DRIVER          0   // 1 = AW9523, 2 = PCF9539, 3 = MCP23017, 4 = PCF8575, 5 = PCF8574, 6 = CH32X035
 // #define RG_I2C_GPIO_ADDR            0x00
 // #define RG_GPIO_I2C_SDA             GPIO_NUM_15
 // #define RG_GPIO_I2C_SCL             GPIO_NUM_4

--- a/components/retro-go/targets/esplay-micro/config.h
+++ b/components/retro-go/targets/esplay-micro/config.h
@@ -10,7 +10,7 @@
 // #define RG_STORAGE_FLASH_PARTITION  "vfs"
 
 // GPIO Extender
-// #define RG_I2C_GPIO_DRIVER          5   // 1 = AW9523, 2 = PCF9539, 3 = MCP23017, 4 = PCF8575, 5 = PCF8574
+// #define RG_I2C_GPIO_DRIVER          5   // 1 = AW9523, 2 = PCF9539, 3 = MCP23017, 4 = PCF8575, 5 = PCF8574, 6 = CH32X035
 #define RG_I2C_GPIO_ADDR            0x20
 
 // Audio

--- a/components/retro-go/targets/mrgc-g32/config.h
+++ b/components/retro-go/targets/mrgc-g32/config.h
@@ -15,7 +15,7 @@
 /****************************************************************************
  * I2C / GPIO Extender                                                      *
  ****************************************************************************/
-// #define RG_I2C_GPIO_DRIVER          0   // 1 = AW9523, 2 = PCF9539, 3 = MCP23017, 4 = PCF8575, 5 = PCF8574
+// #define RG_I2C_GPIO_DRIVER          0   // 1 = AW9523, 2 = PCF9539, 3 = MCP23017, 4 = PCF8575, 5 = PCF8574, 6 = CH32X035
 #define RG_I2C_GPIO_ADDR            0x20
 #define RG_GPIO_I2C_SDA             GPIO_NUM_21
 #define RG_GPIO_I2C_SCL             GPIO_NUM_22

--- a/components/retro-go/targets/mrgc-gbm/config.h
+++ b/components/retro-go/targets/mrgc-gbm/config.h
@@ -10,7 +10,7 @@
 // #define RG_STORAGE_FLASH_PARTITION  "vfs"
 
 // GPIO Extender
-// #define RG_I2C_GPIO_DRIVER          0   // 1 = AW9523, 2 = PCF9539, 3 = MCP23017
+// #define RG_I2C_GPIO_DRIVER          0   // 1 = AW9523, 2 = PCF9539, 3 = MCP23017, 6 = CH32X035
 #define RG_I2C_GPIO_ADDR            0x20
 
 // Audio

--- a/components/retro-go/targets/odroid-go/config.h
+++ b/components/retro-go/targets/odroid-go/config.h
@@ -15,7 +15,7 @@
 /****************************************************************************
  * I2C / GPIO Extender                                                      *
  ****************************************************************************/
-// #define RG_I2C_GPIO_DRIVER          0   // 1 = AW9523, 2 = PCF9539, 3 = MCP23017, 4 = PCF8575, 5 = PCF8574
+// #define RG_I2C_GPIO_DRIVER          0   // 1 = AW9523, 2 = PCF9539, 3 = MCP23017, 4 = PCF8575, 5 = PCF8574, 6 = CH32X035
 // #define RG_I2C_GPIO_ADDR            0x00
 // #define RG_GPIO_I2C_SDA             GPIO_NUM_15
 // #define RG_GPIO_I2C_SCL             GPIO_NUM_4

--- a/components/retro-go/targets/redroid-go/config.h
+++ b/components/retro-go/targets/redroid-go/config.h
@@ -10,7 +10,7 @@
 // #define RG_STORAGE_FLASH_PARTITION  "vfs"
 
 // GPIO Extender
-// #define RG_I2C_GPIO_DRIVER          0   // 1 = AW9523, 2 = PCF9539, 3 = MCP23017
+// #define RG_I2C_GPIO_DRIVER          0   // 1 = AW9523, 2 = PCF9539, 3 = MCP23017, 6 = CH32X035
 // #define RG_I2C_GPIO_ADDR            0x00
 
 // Audio

--- a/components/retro-go/targets/retro-ruler/config.h
+++ b/components/retro-go/targets/retro-ruler/config.h
@@ -17,7 +17,7 @@
 /****************************************************************************
  * I2C / GPIO Extender                                                      *
  ****************************************************************************/
-// #define RG_I2C_GPIO_DRIVER          0   // 1 = AW9523, 2 = PCF9539, 3 = MCP23017, 4 = PCF8575, 5 = PCF8574
+// #define RG_I2C_GPIO_DRIVER          0   // 1 = AW9523, 2 = PCF9539, 3 = MCP23017, 4 = PCF8575, 5 = PCF8574, 6 = CH32X035
 // #define RG_I2C_GPIO_ADDR            0x00
 // #define RG_GPIO_I2C_SDA             GPIO_NUM_15
 // #define RG_GPIO_I2C_SCL             GPIO_NUM_4

--- a/components/retro-go/targets/t-deck-plus/config.h
+++ b/components/retro-go/targets/t-deck-plus/config.h
@@ -7,7 +7,7 @@
 #define RG_STORAGE_SDSPI_SPEED      SDMMC_FREQ_DEFAULT
 
 // GPIO Extender
-// #define RG_I2C_GPIO_DRIVER          0   // 1 = AW9523, 2 = PCF9539, 3 = MCP23017
+// #define RG_I2C_GPIO_DRIVER          0   // 1 = AW9523, 2 = PCF9539, 3 = MCP23017, 6 = CH32X035
 #define RG_I2C_GPIO_ADDR            T_DECK_KBD_ADDRESS
 
 // Audio

--- a/components/retro-go/targets/vmu-s3/config.h
+++ b/components/retro-go/targets/vmu-s3/config.h
@@ -16,7 +16,7 @@
 /****************************************************************************
  * I2C / GPIO Extender                                                      *
  ****************************************************************************/
-// #define RG_I2C_GPIO_DRIVER          0   // 1 = AW9523, 2 = PCF9539, 3 = MCP23017, 4 = PCF8575, 5 = PCF8574
+// #define RG_I2C_GPIO_DRIVER          0   // 1 = AW9523, 2 = PCF9539, 3 = MCP23017, 4 = PCF8575, 5 = PCF8574, 6 = CH32X035
 // #define RG_I2C_GPIO_ADDR            0x00
 // #define RG_GPIO_I2C_SDA             GPIO_NUM_NC
 // #define RG_GPIO_I2C_SCL             GPIO_NUM_NC


### PR DESCRIPTION
The Fri3d 2026 Badge uses a CH32X035 microcontroller as an IO expander, because it was cheaper and more versatile than other off-the-shelf IO expanders.

The API is similar to the PCF9539, with different register addresses and (currently) fewer settings like direction, pull-up etc.

I'm submitting this as a draft for now, pending a bit more testing and feedback, but it seems to work just fine already.